### PR TITLE
Add minimal requirements file and update setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Other notebooks download their data directly from the UCI Machine Learning Repos
    ```bash
    pip install -r requirements.txt
    ```
-   Jupyter is required to open the notebooks. If it is not already installed,
-   run `pip install jupyter` as well.
+   This installs Jupyter along with the required libraries.
 3. Launch Jupyter Notebook:
    ```bash
    jupyter notebook

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-numpy==1.19.5
-pandas==1.1.5
-scipy==1.4.1
-scikit-learn==0.23.1
-matplotlib==3.2.2
-seaborn==0.11.2
-keras==2.4.3
-google-colab==1.0.0
+pandas
+numpy
+scikit-learn
+matplotlib
+keras
+jupyter


### PR DESCRIPTION
## Summary
- simplify `requirements.txt` with only the packages needed by the notebooks
- clarify that `pip install -r requirements.txt` installs Jupyter in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f55f8f6483328416df3c88a447f4