### PR TITLE
Add script for clearing notebook outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Other notebooks download their data directly from the UCI Machine Learning Repos
 
 Datasets included in this repository (`diabetes.csv` and `Ch3.ClevelandData.csv`) are ready to use. Notebooks that reference online sources will automatically download the data when run.
 
+## Contributing
+
+Before submitting changes, please clear the outputs of all notebooks so Git diffs remain readable. You can do this automatically by running:
+
+```bash
+scripts/clear_outputs.sh
+```
+
+This script runs `jupyter nbconvert --clear-output --inplace` on every `.ipynb` file in the repository.
+
 
 ## License
 

--- a/scripts/clear_outputs.sh
+++ b/scripts/clear_outputs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Find all Jupyter notebooks in the repository and clear their outputs inplace.
+# This helps keep Git diffs small by excluding runtime execution results.
+
+set -e
+
+find . -name '*.ipynb' -print0 | xargs -0 jupyter nbconvert --clear-output --inplace


### PR DESCRIPTION
## Summary
- create `scripts/clear_outputs.sh` to wipe Jupyter notebook outputs
- document the new script in the README Contributing section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847f5615f1c8332a12edb28240ee372