### PR TITLE
Add notebook and dataset tests

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,21 @@
+import csv
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+def load_csv(path):
+    with open(path, newline='') as f:
+        reader = csv.reader(f)
+        return list(reader)
+
+def test_diabetes_dataset_shape():
+    rows = load_csv(ROOT / 'diabetes.csv')
+    header, data = rows[0], rows[1:]
+    assert len(header) == 9
+    assert len(data) == 768  # number of data rows
+    assert all(len(r) == 9 for r in data)
+
+def test_cleveland_dataset_shape():
+    rows = load_csv(ROOT / 'Ch3.ClevelandData.csv')
+    assert len(rows) == 303
+    assert all(len(r) == 14 for r in rows)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,10 @@
+import nbformat
+from nbconvert import PythonExporter
+
+
+def test_breast_cancer_notebook_compiles():
+    """Ensure Breast_cancer_projects.ipynb converts to valid Python code."""
+    nb = nbformat.read('Breast_cancer_projects.ipynb', as_version=4)
+    source, _ = PythonExporter().from_notebook_node(nb)
+    # Compilation should fail if there are syntax errors
+    compile(source, 'Breast_cancer_projects.ipynb', 'exec')


### PR DESCRIPTION
## Summary
- test that key notebook compiles after nbconvert
- ensure dataset CSVs load with expected shapes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nbformat')*

------
https://chatgpt.com/codex/tasks/task_e_688c74fa43348332896b9ce52a05edea