### PR TITLE
test: compile all notebooks

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,10 +1,19 @@
+import pathlib
+
 import nbformat
+import pytest
 from nbconvert import PythonExporter
 
 
-def test_breast_cancer_notebook_compiles():
-    """Ensure Breast_cancer_projects.ipynb converts to valid Python code."""
-    nb = nbformat.read('Breast_cancer_projects.ipynb', as_version=4)
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+NOTEBOOKS = list(ROOT.glob("*.ipynb"))
+
+
+@pytest.mark.parametrize("notebook_path", NOTEBOOKS, ids=lambda p: p.name)
+def test_notebook_compiles(notebook_path):
+    """Ensure each notebook converts to valid Python code."""
+    nb = nbformat.read(notebook_path, as_version=4)
     source, _ = PythonExporter().from_notebook_node(nb)
     # Compilation should fail if there are syntax errors
-    compile(source, 'Breast_cancer_projects.ipynb', 'exec')
+    compile(source, str(notebook_path), "exec")
+

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,13 @@
+"""Simple tests for repository metadata files."""
 
-def test_placeholder():
-    assert True
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_requirements_pinned():
+    """All requirements should pin exact versions."""
+    path = ROOT / "requirements.txt"
+    lines = [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    assert lines, "requirements.txt is empty"
+    assert all("==" in line for line in lines)


### PR DESCRIPTION
## Summary
- check that every notebook converts to valid Python code
- ensure `requirements.txt` pins exact dependency versions

## Testing
- `pip install nbformat nbconvert` *(failed: Could not find a version that satisfies the requirement nbformat)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'nbformat')*

------
https://chatgpt.com/codex/tasks/task_e_689c7948951c8332815975c6f45c4693