### PR TITLE
Add notebook deps and strengthen data tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ scripts/clear_outputs.sh
 
 This script runs `jupyter nbconvert --clear-output --inplace` on every `.ipynb` file in the repository.
 
+After clearing notebook outputs, run the test suite to verify your changes:
+
+```bash
+pytest
+```
+
 
 ## License
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ scikit-learn==1.2.2
 matplotlib==3.7.1
 keras==2.11.0
 jupyter==1.0.0
+nbformat==5.9.2
+nbconvert==7.8.0

--- a/scripts/clear_outputs.sh
+++ b/scripts/clear_outputs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Find all Jupyter notebooks in the repository and clear their outputs inplace.
+# Find all tracked Jupyter notebooks and clear their outputs in place.
 # This helps keep Git diffs small by excluding runtime execution results.
 
 set -e
 
-find . -name '*.ipynb' -print0 | xargs -0 jupyter nbconvert --clear-output --inplace
+# Use git to list notebooks, avoiding untracked directories
+git ls-files '*.ipynb' | xargs -r jupyter nbconvert --clear-output --inplace

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -15,7 +15,28 @@ def test_diabetes_dataset_shape():
     assert len(data) == 768  # number of data rows
     assert all(len(r) == 9 for r in data)
 
+
+def is_float(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+
+def test_diabetes_dataset_values():
+    rows = load_csv(ROOT / 'diabetes.csv')
+    data = rows[1:]
+    assert all(all(is_float(c) for c in row) for row in data)
+    assert all(all(c.strip() for c in row) for row in data)
+
 def test_cleveland_dataset_shape():
     rows = load_csv(ROOT / 'Ch3.ClevelandData.csv')
     assert len(rows) == 303
     assert all(len(r) == 14 for r in rows)
+
+
+def test_cleveland_dataset_values():
+    rows = load_csv(ROOT / 'Ch3.ClevelandData.csv')
+    assert all(all(is_float(c) for c in row) for row in rows)
+    assert all(all(c.strip() for c in row) for row in rows)


### PR DESCRIPTION
## Summary
- pin nbformat and nbconvert to ensure notebook tests run
- clarify contributor guidelines to run pytest and refine output clearing script
- validate dataset CSVs contain numeric, non-missing values

## Testing
- `pip install nbformat==5.9.2 nbconvert==7.8.0 -q` *(fails: Could not find a version that satisfies the requirement nbformat==5.9.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nbformat')*

------
https://chatgpt.com/codex/tasks/task_e_689dd587577083328dc086f910480f91