### PR TITLE
Handle spaces in notebook filenames

### DIFF
--- a/scripts/clear_outputs.sh
+++ b/scripts/clear_outputs.sh
@@ -6,4 +6,5 @@
 set -e
 
 # Use git to list notebooks, avoiding untracked directories
-git ls-files '*.ipynb' | xargs -r jupyter nbconvert --clear-output --inplace
+# The -z and -0 options allow filenames with spaces to be handled safely
+git ls-files -z '*.ipynb' | xargs -0 -r jupyter nbconvert --clear-output --inplace


### PR DESCRIPTION
## Summary
- ensure `clear_outputs.sh` safely handles notebooks with spaces using `git ls-files -z` and `xargs -0`

## Testing
- `PATH="$PWD:$PATH" bash scripts/clear_outputs.sh`
- `pytest` *(fails: ModuleNotFoundError: No module named 'nbformat')*

------
https://chatgpt.com/codex/tasks/task_e_689de5e000b08332b26141fcaa572432