### PR TITLE
Add pytest to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ keras==2.11.0
 jupyter==1.0.0
 nbformat==5.9.2
 nbconvert==7.8.0
+pytest==8.4.1


### PR DESCRIPTION
## Summary
- add pytest pin to requirements for consistent testing environment

## Testing
- `pip install -r requirements.txt` (fails: Could not find a version that satisfies the requirement pandas==1.5.3)
- `pytest` (fails: No module named 'nbformat')

------
https://chatgpt.com/codex/tasks/task_e_689de5cc473c833294fce0df0819bc77