### PR TITLE
Use git ls-files for notebook tests

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,4 +1,5 @@
 import pathlib
+import subprocess
 
 import nbformat
 import pytest
@@ -6,7 +7,12 @@ from nbconvert import PythonExporter
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-NOTEBOOKS = list(ROOT.glob("*.ipynb"))
+NOTEBOOKS = [
+    ROOT / path
+    for path in subprocess.check_output(
+        ["git", "ls-files", "*.ipynb"], cwd=ROOT, text=True
+    ).splitlines()
+]
 
 
 @pytest.mark.parametrize("notebook_path", NOTEBOOKS, ids=lambda p: p.name)


### PR DESCRIPTION
## Summary
- List tracked notebooks using `git ls-files` for notebook tests

## Testing
- `pytest` *(fails: No module named 'nbformat')*
- `pytest tests/test_notebooks.py` *(fails: No module named 'nbformat')*


------
https://chatgpt.com/codex/tasks/task_e_689de5b96a5483328c74950590d00f60